### PR TITLE
refactor: Use embed-resource crate to compile resources

### DIFF
--- a/.changes/compile-for.md
+++ b/.changes/compile-for.md
@@ -1,0 +1,5 @@
+---
+"winres": patch
+---
+
+Added `compile_for` function to select which binaries to apply the resource to.

--- a/.changes/use-embed-resource.md
+++ b/.changes/use-embed-resource.md
@@ -1,0 +1,5 @@
+---
+"winres": patch
+---
+
+Use https://github.com/nabijaczleweli/rust-embed-resource to compile the resource for better cross-platform compilation support.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,12 +10,9 @@ license = "MIT"
 repository = "https://github.com/tauri-apps/winres"
 documentation = "https://docs.rs/tauri-winres/"
 
-[lib]
-path = "lib.rs"
-
 [dependencies]
-toml = "0.5"
-version_check = "0.9"
+toml = "0.7"
+embed-resource = "2.1"
 
 [dev-dependencies]
 winapi = { version = "0.3", features = [ "winnt" ] }

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # tauri-winres
 
-A simple library to facilitate adding [Resources](<https://en.wikipedia.org/wiki/Resource_(Windows)>) (metainformation and icons) to [Portable Executables](https://en.wikipedia.org/wiki/Portable_Executable) (Windows executables and dynamic libraries).
+A simple library to facilitate adding [Resources](<https://en.wikipedia.org/wiki/Resource_(Windows)>) (metainformation and icons) to [Portable Executables](https://en.wikipedia.org/wiki/Portable_Executable).
 
-Note: `tauri-winres` is a fork of [winres](https://github.com/mxre/winres) which no longer works on Rust 1.61 or higher and has been [left unmaintained](https://github.com/mxre/winres/issues/40).
+Note: `tauri-winres` is a fork of [winres](https://github.com/mxre/winres) which no longer works on Rust 1.61 or higher and has been [left unmaintained](https://github.com/mxre/winres/issues/40). This fork completely replaced the resource compiler implementation with the awesome [embed-resource](https://github.com/nabijaczleweli/rust-embed-resource) crate for better cross-platform compilation support. This fork was primarily updated and modified for use in [Tauri](https://github.com/tauri-apps/tauri). For a more general-purpose-like fork, which currently sticks closer to upstream, we suggest to also take a look at [winresource](https://github.com/BenjaminRi/winresource).
 
 [Documentation](https://docs.rs/tauri-winres/)
 
@@ -10,15 +10,15 @@ Note: `tauri-winres` is a fork of [winres](https://github.com/mxre/winres) which
 
 Before we begin you need to have the appropriate tools installed.
 
--   `rc.exe` from the [Windows SDK]
--   `windres.exe` and `ar.exe` from [minGW64]
+- `rc.exe` from the [Windows SDK]
+- `windres.exe` and `ar.exe` from [minGW64]
 
 [windows sdk]: https://developer.microsoft.com/en-us/windows/downloads/windows-10-sdk
 [mingw64]: http://mingw-w64.org
 
-If you are using Rust with the MSVC ABI you will need the Windows SDK for the GNU ABI you'll need minGW64.
+If you are using Rust with the MSVC ABI you will need the Windows SDK and for the GNU ABI you'll need minGW64.
 
-Windows SDK can be found in the registry, minGW64 has to be in the path.
+The Windows SDK can generally be found in the registry, but minGW64 must be in the $PATH environment.
 
 ## Using tauri-winres
 
@@ -49,7 +49,7 @@ fn main() {
 
 That's it. The file `test.ico` should be located in the same directory as `build.rs`. Metainformation (like program version and description) is taken from `Cargo.toml`'s `[package]` section.
 
-Note that support for using this crate on non windows platforms is experimental. It is recommended to only use `tauri-winres` on Windows hosts, by using `cfg` as a directive to avoid building `tauri-winres` on unix platforms alltogether.
+Note that support for using this crate on non-Windows platforms is experimental. It is recommended to only use `tauri-winres` on Windows hosts, by using `cfg` as a directive to avoid building `tauri-winres` on unix platforms alltogether.
 
 ```toml
 [package]
@@ -99,6 +99,6 @@ See [MSDN] for more details on the version info section of executables/libraries
 
 ## About this project
 
-The [original author](https://github.com/mxre) and maintainers use this crate for their personal projects and although is has been tested in that context, we have no idea if the behaviour is the same everywhere.
+The [original author](https://github.com/mxre) and maintainers use this crate for their personal projects and although it has been tested in that context, we have no idea if the behaviour is the same everywhere.
 
 To be brief, we are very much reliant on your bug reports and feature suggestions to make this crate better.

--- a/example/build.rs
+++ b/example/build.rs
@@ -8,14 +8,6 @@ fn main() {
     // as calling rc.exe might be slow
     if std::env::var("PROFILE").unwrap() == "release" {
         let mut res = tauri_winres::WindowsResource::new();
-        if cfg!(unix) {
-            // paths for X64 on archlinux
-            res.set_toolkit_path("/usr/x86_64-w64-mingw32/bin");
-            // ar tool for mingw in toolkit path
-            res.set_ar_path("ar");
-            // windres tool
-            res.set_windres_path("/usr/bin/x86_64-w64-mingw32-windres");
-        }
 
         res.set_icon("icon.ico")
             // can't use winapi crate constants for cross compiling

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -1,0 +1,62 @@
+use std::{
+    collections::HashMap,
+    env,
+    fs::File,
+    io::{self, Read},
+    path::Path,
+};
+
+pub(crate) fn parse_cargo_toml(props: &mut HashMap<String, String>) -> io::Result<()> {
+    let cargo = Path::new(&env::var("CARGO_MANIFEST_DIR").unwrap()).join("Cargo.toml");
+    let mut f = File::open(cargo)?;
+    let mut cargo_toml = String::new();
+    f.read_to_string(&mut cargo_toml)?;
+    if let Ok(ml) = cargo_toml.parse::<toml::Value>() {
+        if let Some(pkg) = ml.get("package") {
+            if let Some(pkg) = pkg.get("metadata") {
+                if let Some(pkg) = pkg.get("tauri-winres") {
+                    if let Some(pkg) = pkg.as_table() {
+                        for (k, v) in pkg {
+                            // println!("{} {}", k ,v);
+                            if let Some(v) = v.as_str() {
+                                props.insert(k.clone(), v.to_string());
+                            } else {
+                                println!("package.metadata.tauri-winres.{} is not a string", k);
+                            }
+                        }
+                    } else {
+                        println!("package.metadata.tauri-winres is not a table");
+                    }
+                } else {
+                    println!("package.metadata.tauri-winres does not exist");
+                }
+            } else {
+                println!("package.metadata does not exist");
+            }
+        } else {
+            println!("package does not exist");
+        }
+    } else {
+        println!("TOML parsing error")
+    }
+    Ok(())
+}
+
+pub(crate) fn escape_string(string: &str) -> String {
+    let mut escaped = String::new();
+    for chr in string.chars() {
+        // In quoted RC strings, double-quotes are escaped by using two
+        // consecutive double-quotes.  Other characters are escaped in the
+        // usual C way using backslashes.
+        match chr {
+            '"' => escaped.push_str("\"\""),
+            '\'' => escaped.push_str("\\'"),
+            '\\' => escaped.push_str("\\\\"),
+            '\n' => escaped.push_str("\\n"),
+            '\t' => escaped.push_str("\\t"),
+            '\r' => escaped.push_str("\\r"),
+            _ => escaped.push(chr),
+        };
+    }
+    escaped
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -523,12 +523,12 @@ impl WindowsResource {
         let rc = output.join("resource.rc");
 
         if let Some(s) = self.rc_file.as_ref() {
-            fs::write(&output, s)?;
+            fs::write(&rc, s)?;
         } else {
-            self.write_resource_file(rc)?;
+            self.write_resource_file(&rc)?;
         }
 
-        embed_resource::compile("resource.rc", embed_resource::NONE);
+        embed_resource::compile(rc, embed_resource::NONE);
 
         Ok(())
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -347,7 +347,10 @@ impl WindowsResource {
     /// ```
     pub fn set_icon_with_id<'a>(&mut self, path: &'a str, name_id: &'a str) -> &mut Self {
         self.icons.push(Icon {
-            path: path.into(),
+            path: PathBuf::from(path)
+                .canonicalize()
+                .map(|p| p.to_string_lossy().to_string())
+                .unwrap_or(path.to_string()),
             name_id: name_id.into(),
         });
         self

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,6 +44,8 @@
 //! [`WindowsResorce::compile()`]: struct.WindowsResource.html#method.compile
 //! [`WindowsResource::new()`]: struct.WindowsResource.html#method.new
 
+mod helpers;
+
 use std::collections::HashMap;
 use std::env;
 use std::fs;
@@ -52,8 +54,6 @@ use std::io::prelude::*;
 use std::path::{Path, PathBuf};
 
 use helpers::{escape_string, parse_cargo_toml};
-
-mod helpers;
 
 /// Version info field names
 #[derive(PartialEq, Eq, Hash, Debug)]


### PR DESCRIPTION
Since there is another winres fork it's hopefully fine to keep this one really specific to tauri.

The reason i did this in the first place is because a community member made me aware of llvm-rc so the ugly mingw workaround i did can be removed again. The only drawback is that this may work less "good" for dyn libs as embed-resource seems to focus on executables (judging by different cargo link flags at least). Coming from the "tauri-specific fork" pov i think this is fine since it still covers our use-case perfectly.

Opened as a draft because i'm still testing os+gnu/msvc combinations:
- [x] Linux->Windows with llvm
- [x] Linux->Windows with gnu
- [x] Windows->Windows with msvc 
- [x] Windows->Windows with gnu

~~TODO: Update readme~~