### PR TITLE
chore(deps): update toml to 0.8

### DIFF
--- a/.changes/toml08-msrv165.md
+++ b/.changes/toml08-msrv165.md
@@ -1,0 +1,5 @@
+---
+tauri-winres: minor
+---
+
+Updated `toml` crate to `0.8`. This raises this crate's MSRV to `1.65`.

--- a/.changes/toml08-msrv165.md
+++ b/.changes/toml08-msrv165.md
@@ -1,5 +1,5 @@
 ---
-tauri-winres: minor
+winres: minor
 ---
 
 Updated `toml` crate to `0.8`. This raises this crate's MSRV to `1.65`.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ repository = "https://github.com/tauri-apps/winres"
 documentation = "https://docs.rs/tauri-winres/"
 
 [dependencies]
-toml = "0.7"
+toml = "0.8"
 embed-resource = "2.1"
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ authors = [
 license = "MIT"
 repository = "https://github.com/tauri-apps/winres"
 documentation = "https://docs.rs/tauri-winres/"
+rust-version = "1.65"
 
 [dependencies]
 toml = "0.8"


### PR DESCRIPTION
repo builds both toml 0.7 and 0.8, this means it only needs 0.8