### PR TITLE
chore(deps): update toml to 0.9 and bump MSRV

### DIFF
--- a/.changes/toml-0.9.md
+++ b/.changes/toml-0.9.md
@@ -1,0 +1,5 @@
+---
+'winres': patch
+---
+
+Update toml to 0.9 and increased the MSRV from 1.65 to 1.66 to match it

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: dtolnay/rust-toolchain@1.65
+      - uses: dtolnay/rust-toolchain@1.66
 
       - name: Build
         run: cargo build

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,11 +9,11 @@ authors = [
 license = "MIT"
 repository = "https://github.com/tauri-apps/winres"
 documentation = "https://docs.rs/tauri-winres/"
-rust-version = "1.65"
+rust-version = "1.66"
 edition = "2021"
 
 [dependencies]
-toml = "0.8"
+toml = "0.9"
 embed-resource = "3"
 indexmap = "2"
 


### PR DESCRIPTION
Reference: https://github.com/tauri-apps/tauri/pull/13784#issuecomment-3136888012

Not entirely sure if this should be a minor bump or patch bump since `embed-resource` already depends on `toml@0.9`